### PR TITLE
Fixing main navigation text color disappearing on hover

### DIFF
--- a/src/lux/assets/css/style.css
+++ b/src/lux/assets/css/style.css
@@ -1,0 +1,3 @@
+ul.us_menu.dark li:hover > a {
+  color: var(--menu-text-hover-color, rgb(0,0,0,0.75));
+}


### PR DESCRIPTION
Since hover action on nav makes background white, it also has a light text color so the text disappears. In this commit i've added a darker text color so nav text can be seen when using lux theme. I tried to keep within the theme visual colors rather than just applying full black.

Source file for original nav is in menu.css but I believe this is probably the correct place for a theme override.